### PR TITLE
[OPP-1495] inkludere tags i søk på tekster

### DIFF
--- a/src/main/kotlin/no/nav/api/skrivestotte/SkrivestotteService.kt
+++ b/src/main/kotlin/no/nav/api/skrivestotte/SkrivestotteService.kt
@@ -67,6 +67,7 @@ class SkrivestotteService (private val skrivestotteClient: SkrivestotteClient) {
         return tekster.associateWith {
             listOf(
                 it.overskrift,
+                it.tags.joinToString("\u0000"),
                 it.innhold.kombinert()
             )
                 .joinToString("\u0000")

--- a/src/test/kotlin/no/nav/mock/MockConsumers.kt
+++ b/src/test/kotlin/no/nav/mock/MockConsumers.kt
@@ -78,7 +78,7 @@ private val skrivestotteClientMock = mockOf<SkrivestotteClient> { client ->
     val tekst = Tekst(
         id = hardkodetUUID,
         overskrift = "TestTekst",
-        tags = emptyList(),
+        tags = listOf("nøs", "kontonummer", "retur"),
         innhold = Innhold(
             nb_NO = "Dette er en tekst",
             nn_NO = "Dette er ein tekst"
@@ -92,7 +92,8 @@ private val skrivestotteClientMock = mockOf<SkrivestotteClient> { client ->
             innhold = Innhold(
                 nb_NO = "Dette er også en tekst",
                 en_US = "This is also a text"
-            )
+            ),
+            tags = emptyList()
         )
     )
 


### PR DESCRIPTION
Søket som robotene gjør på tekster i dag er basert på tags, så det er fint å inkludere også dette i vår løsning hvis de ønsker å fortsette med samme type søk