### PR TITLE
[KAIZEN-0] fikse serialisering av graphql-requester

### DIFF
--- a/src/main/kotlin/no/nav/api/dialog/saf/SafClient.kt
+++ b/src/main/kotlin/no/nav/api/dialog/saf/SafClient.kt
@@ -1,14 +1,9 @@
 package no.nav.api.dialog.saf
 
-import io.ktor.client.*
 import io.ktor.client.engine.*
 import io.ktor.client.engine.okhttp.*
-import io.ktor.client.features.json.*
-import io.ktor.client.features.json.serializer.*
 import io.ktor.client.request.*
 import no.nav.api.dialog.saf.queries.HentBrukerssaker
-import no.nav.common.token_client.client.MachineToMachineTokenClient
-import no.nav.personoversikt.utils.SelftestGenerator
 import no.nav.utils.*
 
 class SafClient(
@@ -16,24 +11,8 @@ class SafClient(
     private val tokenclient: BoundedMachineToMachineTokenClient,
     httpEngine: HttpClientEngine = OkHttp.create()
 ) {
-    private val safApi = DownstreamApi(
-        cluster = "prod-fss",
-        namespace = "teamdokumenthandtering",
-        application = "saf"
-    )
-
-    private val httpClient = HttpClient(httpEngine) {
-        install(JsonFeature) {
-            serializer = KotlinxSerializer(
-                kotlinx.serialization.json.Json {
-                    ignoreUnknownKeys = true
-                }
-            )
-        }
-    }
-
     private val graphqlClient = GraphQLClient(
-        httpClient = httpClient,
+        httpClient = GraphQLClient.createHttpClient(httpEngine),
         config = GraphQLClientConfig(
             serviceName = "SAF",
             critical = false,

--- a/src/main/kotlin/no/nav/api/pdl/PdlClient.kt
+++ b/src/main/kotlin/no/nav/api/pdl/PdlClient.kt
@@ -1,11 +1,8 @@
 package no.nav.api.pdl
 
 import HentAktorid
-import io.ktor.client.*
 import io.ktor.client.engine.*
 import io.ktor.client.engine.okhttp.*
-import io.ktor.client.features.json.*
-import io.ktor.client.features.json.serializer.*
 import io.ktor.client.request.*
 import no.nav.api.pdl.queries.HentPersonalia
 import no.nav.utils.*
@@ -15,18 +12,8 @@ class PdlClient(
     private val tokenclient: BoundedMachineToMachineTokenClient,
     httpEngine: HttpClientEngine = OkHttp.create()
 ) {
-    private val httpClient = HttpClient(httpEngine) {
-        install(JsonFeature) {
-            serializer = KotlinxSerializer(
-                kotlinx.serialization.json.Json {
-                    ignoreUnknownKeys = true
-                }
-            )
-        }
-    }
-
     private val graphqlClient = GraphQLClient(
-        httpClient = httpClient,
+        httpClient = GraphQLClient.createHttpClient(httpEngine),
         config = GraphQLClientConfig(
             serviceName = "PDL",
             critical = false,

--- a/src/main/kotlin/no/nav/utils/GraphQLClient.kt
+++ b/src/main/kotlin/no/nav/utils/GraphQLClient.kt
@@ -2,12 +2,15 @@ package no.nav.utils
 
 import io.ktor.client.*
 import io.ktor.client.call.*
+import io.ktor.client.engine.*
+import io.ktor.client.features.json.*
+import io.ktor.client.features.json.serializer.*
 import io.ktor.client.request.*
-import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import kotlinx.serialization.Serializable
 import no.nav.personoversikt.utils.SelftestGenerator
-import java.util.UUID
+import java.util.*
 
 interface GraphQLVariables
 interface GraphQLResult
@@ -94,6 +97,17 @@ class GraphQLClient(
                 ?.readText()
                 ?.replace("[\n\r]", "")
                 ?: throw Exception("Unknown graphql file: \"/$source/$name.graphql\"")
+        }
+
+        fun createHttpClient(httpEngine: HttpClientEngine): HttpClient = HttpClient(httpEngine) {
+            install(JsonFeature) {
+                serializer = KotlinxSerializer(
+                    kotlinx.serialization.json.Json {
+                        ignoreUnknownKeys = true
+                        encodeDefaults = true
+                    }
+                )
+            }
         }
     }
 }

--- a/src/test/kotlin/no/nav/api/pdl/PdlTest.kt
+++ b/src/test/kotlin/no/nav/api/pdl/PdlTest.kt
@@ -2,12 +2,14 @@ package no.nav.api.pdl
 
 import io.ktor.client.engine.mock.*
 import io.ktor.http.*
+import io.ktor.http.content.*
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.LocalDate
 import no.nav.utils.BoundedMachineToMachineTokenClient
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 
@@ -15,6 +17,9 @@ internal class PdlTest {
     @Test
     fun `should be able to deserialize pdl response`() = runBlocking {
         val mockEngine = MockEngine { request ->
+            val body = (request.body as TextContent).text
+            assertTrue(body.contains("variables"))
+            assertTrue(body.contains("hentPerson"))
             respond(
                 status = HttpStatusCode.OK,
                 headers = headersOf(


### PR DESCRIPTION
`query` har en default-verdi, og vil ut-av-boksen ikke bli sendt ved bruk av kotlinx-serialization. Må derfor sikre at serialiseren er konfigurert med `encodeDefaults = true`
