### PR TITLE
[KAIZEN-0] fikse pdl-graphql queries

### DIFF
--- a/src/main/kotlin/no/nav/api/pdl/PdlService.kt
+++ b/src/main/kotlin/no/nav/api/pdl/PdlService.kt
@@ -19,7 +19,7 @@ class PdlService(
     }
 
     suspend fun hentAktorid(fnr: String): String {
-        return requireNotNull(client.hentAktorid(fnr).data?.hentAktorid?.ident)
+        return requireNotNull(client.hentAktorid(fnr).data?.hentIdenter?.identer?.firstOrNull()?.ident)
     }
 
     private fun hentAlder(person: HentPersonalia.Person?): Int? {

--- a/src/main/kotlin/no/nav/api/pdl/queries/HentAktorid.kt
+++ b/src/main/kotlin/no/nav/api/pdl/queries/HentAktorid.kt
@@ -18,8 +18,11 @@ data class HentAktorid(override val variables: Variables)
     }
 
     @Serializable
-    data class Result(val hentAktorid: Aktorid) : GraphQLResult
+    data class IdentInfo(val ident: String)
 
     @Serializable
-    data class Aktorid(val ident: String)
+    data class IdentListe(val identer: List<IdentInfo>)
+
+    @Serializable
+    data class Result(val hentIdenter: IdentListe?) : GraphQLResult
 }

--- a/src/main/kotlin/no/nav/api/pdl/queries/HentPersonalia.kt
+++ b/src/main/kotlin/no/nav/api/pdl/queries/HentPersonalia.kt
@@ -17,7 +17,7 @@ data class HentPersonalia(override val variables: Variables)
     data class Variables(val ident: String) : GraphQLVariables
 
     @Serializable
-    data class Result(val hentPerson: Person) : GraphQLResult
+    data class Result(val hentPerson: Person?) : GraphQLResult
 
     @Serializable
     data class Person(

--- a/src/test/kotlin/no/nav/mock/MockConsumers.kt
+++ b/src/test/kotlin/no/nav/mock/MockConsumers.kt
@@ -147,7 +147,13 @@ private val pdlClientMock = mockOf<PdlClient> {client ->
     )
     coEvery { client.hentAktorid(any()) } returns GraphQLResponse(
         data = HentAktorid.Result(
-            hentAktorid = HentAktorid.Aktorid(ident = "10108000398")
+            hentIdenter = HentAktorid.IdentListe(
+                identer = listOf(
+                    HentAktorid.IdentInfo(
+                        ident = "10108000398"
+                    )
+                )
+            )
         )
     )
 }


### PR DESCRIPTION
må kunne håndtere null-response om person ikke finnes, og fikset `HentAktorId` til å være i samsvar med pdl schema
