### PR TITLE
[KAIZEN-0] lage statuspages

### DIFF
--- a/src/main/kotlin/no/nav/Application.kt
+++ b/src/main/kotlin/no/nav/Application.kt
@@ -26,6 +26,7 @@ fun startApplication(
         configureSecurity(disableSecurity, env)
         configureMonitoring()
         configureSerialization()
+        configureExceptionHandling()
 
         routing {
             notarizedAuthenticate(securityScheme) {

--- a/src/main/kotlin/no/nav/api/utbetalinger/UtbetalingerClient.kt
+++ b/src/main/kotlin/no/nav/api/utbetalinger/UtbetalingerClient.kt
@@ -1,10 +1,9 @@
 package no.nav.api.utbetalinger
 
+import io.ktor.http.*
 import kotlinx.datetime.LocalDate
 import no.nav.common.cxf.StsConfig
-import no.nav.tjeneste.virksomhet.utbetaling.v1.HentUtbetalingsinformasjonIkkeTilgang
-import no.nav.tjeneste.virksomhet.utbetaling.v1.HentUtbetalingsinformasjonPeriodeIkkeGyldig
-import no.nav.tjeneste.virksomhet.utbetaling.v1.HentUtbetalingsinformasjonPersonIkkeFunnet
+import no.nav.plugins.WebStatusException
 import no.nav.tjeneste.virksomhet.utbetaling.v1.UtbetalingV1
 import no.nav.tjeneste.virksomhet.utbetaling.v1.informasjon.*
 import no.nav.tjeneste.virksomhet.utbetaling.v1.meldinger.WSHentUtbetalingsinformasjonRequest
@@ -41,14 +40,11 @@ class UtbetalingerClient(
             )
         try {
             client.hentUtbetalingsinformasjon(request).utbetalingListe
-        } catch (ex: HentUtbetalingsinformasjonPeriodeIkkeGyldig) {
-            throw RuntimeException("Utbetalingsperioden er ikke gyldig. ", ex)
-        } catch (ex: HentUtbetalingsinformasjonPersonIkkeFunnet) {
-            throw RuntimeException("Person ikke funnet. ", ex)
-        } catch (ex: HentUtbetalingsinformasjonIkkeTilgang) {
-            throw RuntimeException("Ikke tilgang. ", ex)
         } catch (ex: Exception) {
-            throw RuntimeException("Henting av utbetalinger for bruker med fnr $fnr mellom $fra og $til feilet.", ex)
+            throw WebStatusException(
+                message = ex.message ?: "Henting av utbetalinger for bruker med fnr $fnr mellom $fra og $til feilet.",
+                status = HttpStatusCode.InternalServerError
+            )
         }
     }
 

--- a/src/main/kotlin/no/nav/plugins/ExceptionHandling.kt
+++ b/src/main/kotlin/no/nav/plugins/ExceptionHandling.kt
@@ -1,0 +1,31 @@
+package no.nav.plugins
+
+import io.ktor.application.*
+import io.ktor.features.*
+import io.ktor.http.*
+import io.ktor.response.*
+
+class WebStatusException(message: String, val status: HttpStatusCode) : Exception(message)
+
+fun Application.configureExceptionHandling() {
+    install(StatusPages) {
+        exception<WebStatusException> { cause ->
+            call.respond(
+                cause.status,
+                HttpErrorResponse(
+                    cause = cause.toString(),
+                    message = cause.message,
+                    
+                )
+            )
+        }
+        exception<Throwable> {
+            call.respond(HttpStatusCode.InternalServerError)
+        }
+    }
+}
+
+internal data class HttpErrorResponse(
+    val message: String? = null,
+    val cause: String? = null
+)

--- a/src/test/kotlin/no/nav/api/utbetalinger/UtbetalingerServiceTest.kt
+++ b/src/test/kotlin/no/nav/api/utbetalinger/UtbetalingerServiceTest.kt
@@ -1,10 +1,11 @@
 package no.nav.api.utbetalinger
 
+import io.ktor.http.*
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.LocalDate
-import no.nav.tjeneste.virksomhet.utbetaling.v1.HentUtbetalingsinformasjonPeriodeIkkeGyldig
+import no.nav.plugins.WebStatusException
 import no.nav.tjeneste.virksomhet.utbetaling.v1.informasjon.WSPeriode
 import no.nav.tjeneste.virksomhet.utbetaling.v1.informasjon.WSUtbetaling
 import no.nav.tjeneste.virksomhet.utbetaling.v1.informasjon.WSYtelse
@@ -35,8 +36,8 @@ internal class UtbetalingerServiceTest {
     
     @Test
     fun `skal feile i service når utbetalingV1 feiler`() {
-        every { runBlocking { client.hentUtbetalinger(any(), any(), any()) } } throws HentUtbetalingsinformasjonPeriodeIkkeGyldig()
-        assertThrows(HentUtbetalingsinformasjonPeriodeIkkeGyldig::class.java) {
+        every { runBlocking { client.hentUtbetalinger(any(), any(), any()) } } throws WebStatusException("Feil mot utbetalinger", HttpStatusCode.InternalServerError)
+        assertThrows(WebStatusException::class.java) {
             runBlocking { service.hentUtbetalinger("12345678910", LocalDate.now(), LocalDate.now()) }
         }
     }


### PR DESCRIPTION
For å vise noe annet enn 500 Internal Server Error når kall mot andre systemer feiler, kan vi eksponere feilmeldingen vi får fra feks Utbetalinger til bruker.