### PR TITLE
[KAIZEN-0] gjøre HttpErrorResponse serialiserbar

### DIFF
--- a/src/main/kotlin/no/nav/plugins/ExceptionHandling.kt
+++ b/src/main/kotlin/no/nav/plugins/ExceptionHandling.kt
@@ -4,6 +4,7 @@ import io.ktor.application.*
 import io.ktor.features.*
 import io.ktor.http.*
 import io.ktor.response.*
+import kotlinx.serialization.Serializable
 
 class WebStatusException(message: String, val status: HttpStatusCode) : Exception(message)
 
@@ -25,6 +26,7 @@ fun Application.configureExceptionHandling() {
     }
 }
 
+@Serializable
 internal data class HttpErrorResponse(
     val message: String? = null,
     val cause: String? = null


### PR DESCRIPTION
Basert på feilmeldingen: https://logs.adeo.no/app/discover#/doc/96e648c0-980a-11e9-830a-e17bbd64b4db/logstash-apps-test-002330?id=-MCnqoIBdH6avESX-xRP