### PR TITLE
[KAIZEN-0] Fjerner header

### DIFF
--- a/src/main/kotlin/no/nav/api/dialog/saf/SafClient.kt
+++ b/src/main/kotlin/no/nav/api/dialog/saf/SafClient.kt
@@ -38,7 +38,6 @@ class SafClient(
                     val token = tokenclient.createMachineToMachineToken()
                     header("Authorization", "Bearer $token")
                     header("X-Correlation-ID", getCallId())
-                    header("Content-Type", "application/json")
                 }
             )
         }


### PR DESCRIPTION
Trenger ikke spesifisere content type her siden det spesifiseres i execute-funksjonen til GraphQLClient. I tillegg så får vi også en UnsafeHeaderException når vi spesifiserer den her slik vi gjorde