### PR TITLE
[OPP-1493] håndtere 204 fra oppfølging

### DIFF
--- a/src/main/kotlin/no/nav/api/oppfolging/OppfolgingClient.kt
+++ b/src/main/kotlin/no/nav/api/oppfolging/OppfolgingClient.kt
@@ -1,10 +1,13 @@
 package no.nav.api.oppfolging
 
 import io.ktor.client.*
+import io.ktor.client.call.*
 import io.ktor.client.engine.okhttp.*
 import io.ktor.client.features.json.*
 import io.ktor.client.features.json.serializer.*
 import io.ktor.client.request.*
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.*
 import kotlinx.serialization.Serializable
 import no.nav.utils.*
 
@@ -50,6 +53,11 @@ class OppfolgingClient(
     }
 
     suspend fun hentOppfolgingVeileder(fnr: String): VeilederIdent? = externalServiceCall {
-        client.get("$oppfolgingUrl/v2/veileder?fnr=$fnr")
+        val response = client.get<HttpResponse>("$oppfolgingUrl/v2/veileder?fnr=$fnr")
+        when (response.status) {
+            HttpStatusCode.NoContent -> null
+            HttpStatusCode.OK -> response.receive()
+            else -> error("Ukjent status code: ${response.status}")
+        }
     }
 }


### PR DESCRIPTION
Hvis bruker ikke har veileder vil vi få en 204 fra Oppfølging sitt API. Dette blir nå eksplisitt håndtert.