### PR TITLE
[OPP-1497] håndtere oppslag som ikke gir noen utbetalinger

### DIFF
--- a/src/main/kotlin/no/nav/api/utbetalinger/UtbetalingerClient.kt
+++ b/src/main/kotlin/no/nav/api/utbetalinger/UtbetalingerClient.kt
@@ -1,10 +1,12 @@
 package no.nav.api.utbetalinger
 
 import io.ktor.client.*
+import io.ktor.client.call.*
 import io.ktor.client.engine.okhttp.*
 import io.ktor.client.features.json.*
 import io.ktor.client.features.json.serializer.*
 import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import kotlinx.datetime.LocalDate
 import kotlinx.serialization.Serializable
@@ -85,14 +87,15 @@ class UtbetalingerClient(
     
     suspend fun hentUtbetalinger(fnr: String, fra: LocalDate, til: LocalDate): List<Utbetaling> = externalServiceCall {
         val request: UtbetaldataRequest = lagUtbetaldataRequest(fnr, fra, til)
-        try {
-            client.post("$utbetalingerUrl/v1/hent-utbetalingsinformasjon/intern") {
-                contentType(ContentType.Application.Json)
-                body = request
-            }
-        } catch (ex: Exception) {
-            throw WebStatusException(
-                message = ex.message ?: "Henting av utbetalinger for bruker med fnr $fnr mellom $fra og $til feilet.",
+        val response = client.post<HttpResponse>("$utbetalingerUrl/v1/hent-utbetalingsinformasjon/intern") {
+            contentType(ContentType.Application.Json)
+            body = request
+        }
+        when (response.status) {
+            HttpStatusCode.NotFound -> emptyList()
+            HttpStatusCode.OK -> response.receive()
+            else -> throw WebStatusException(
+                message = "Henting av utbetalinger for bruker med fnr $fnr mellom $fra og $til feilet.",
                 status = HttpStatusCode.InternalServerError
             )
         }


### PR DESCRIPTION
Sokos-utbetal sitt API returnerer 404 når oppslaget ikke gir noen resultat. Her ønsker vi å returnere 200 OK og en tom liste, i stedet for at vi sender en feil tilbake til våre brukere.