### PR TITLE
[KAIZEN-0] overskrive fagsaksystem hvis fagsakId er null

### DIFF
--- a/src/main/kotlin/no/nav/api/dialog/DialogService.kt
+++ b/src/main/kotlin/no/nav/api/dialog/DialogService.kt
@@ -49,7 +49,7 @@ class DialogService(
         val journalforRequest = JournalforRequest(
             journalforendeEnhet = request.enhet,
             fagsakId = sak?.fagsakId,
-            fagsaksystem = sak?.fagsaksystem,
+            fagsaksystem = if (sak?.fagsakId != null) sak.fagsaksystem else null,
             temakode = request.tema,
             kjedeId = nyHenvendelse.kjedeId
         )
@@ -64,7 +64,7 @@ class DialogService(
         val journalforRequest = JournalforRequest(
             journalforendeEnhet = request.enhet,
             fagsakId = sak?.fagsakId,
-            fagsaksystem = sak?.fagsaksystem,
+            fagsaksystem = if (sak?.fagsakId != null) sak.fagsaksystem else null,
             temakode = request.tema,
             kjedeId = nyHenvendelse.kjedeId
         )


### PR DESCRIPTION
I tilfellene der vi har en generell sak, vil vi sende med `fagsakId=null` og `fagsaksystem=noe`, som vil trigge en feil hos SF (og hos dokarkiv sitt API, i følge SF?).