### PR TITLE
Patcher Netty-sårbarheit ved å bumpe ktor

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ import com.expediagroup.graphql.plugin.gradle.tasks.GraphQLGenerateClientTask
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer
 
-val ktor_version = "3.0.3"
+val ktor_version = "3.5.2"
 val kotlin_version = "2.0.21"
 val kotlinx_datetime_version = "0.6.2"
 val kompendium_version = "4.0.3"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ val logstash_version = "9.0"
 val prometeus_version = "1.16.1"
 val nav_common_version = "3.2025.10.10_08.21-bb7c7830d93c"
 val tjenestespec_version = "1.2021.02.22-10.45-4201aaea72fb"
-val modia_common_utils_version = "1.2025.09.15-12.01-37deb02592aa"
+val modia_common_utils_version = "1.2026.08.06-12.11-d922f6248916"
 val junit_version = "6.0.1"
 val graphql_kotlin_version = "8.8.1"
 

--- a/src/main/kotlin/no/nav/plugins/OpenApi.kt
+++ b/src/main/kotlin/no/nav/plugins/OpenApi.kt
@@ -2,7 +2,6 @@ package no.nav.plugins
 
 import io.bkbn.kompendium.core.attribute.KompendiumAttributes
 import io.bkbn.kompendium.core.plugin.NotarizedApplication
-import io.bkbn.kompendium.core.routes.swagger
 import io.bkbn.kompendium.json.schema.definition.TypeDefinition
 import io.bkbn.kompendium.oas.OpenApiSpec
 import io.bkbn.kompendium.oas.component.Components
@@ -14,7 +13,6 @@ import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlin.reflect.typeOf
 
@@ -34,6 +32,7 @@ fun Application.configureOpenApi() {
     install(NotarizedApplication()) {
         spec = {
             OpenApiSpec(
+                jsonSchemaDialect = "https://spec.openapis.org/oas/3.1/dialect/base",
                 info =
                     Info(
                         "modia-robot-api",
@@ -70,6 +69,27 @@ fun Application.configureOpenApi() {
     }
 
     routing {
-        swagger(pageTitle = "Modia Robot API")
+        get("swagger-ui") {
+            call.respondText(
+                contentType = ContentType.Text.Html,
+                status = HttpStatusCode.OK,
+                text = """<!DOCTYPE html>
+                        <html>
+                        <head>
+                          <title>Modia Robot API</title>
+                          <meta charset="utf-8"/>
+                          <meta name="viewport" content="width=device-width, initial-scale=1">
+                          <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist/swagger-ui.css">
+                        </head>
+                        <body>
+                        <div id="swagger-ui"></div>
+                        <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js"></script>
+                        <script>
+                          SwaggerUIBundle({ url: '/openapi.json', dom_id: '#swagger-ui', presets: [SwaggerUIBundle.presets.apis] })
+                        </script>
+                        </body>
+                        </html>""",
+            )
+        }
     }
 }


### PR DESCRIPTION
 Bumper ktor frå 3.0.3 til 3.5.2 og modia-common-utils til siste versjon.

Deretter krevdes ein fiks for å få swaggerfila til å fungere:
Kompendium 4.0.3 (siste versjon på Maven Central) ble bygd mot Ktor 3.0.1 og er inkompatibel med
Ktor 3.5.x. Dette krasja /swagger-ui-endepunktet med 500.

Fika ved å erstatte kompendiums swagger()-route med en enkel HTML-route som laster swagger-ui fra
CDN og peker på /openapi.json (denne fila finnes ikkje i classpath, kun runtime). Kompendium brukes fortsatt til å generere OpenAPI-spesifikasjonen
dynamisk.